### PR TITLE
README.md - changed config from json to js to be able to use env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,22 @@
 
 ```npm install --save https://github.com/kyuumeitai/strapi-provider-upload-minio.git```
 
-New strapi beta: the settings are in a json file, you need to put this file in your project:
+New strapi beta: the settings are in a js file, you need to put this file in your project:
 
-./extensions/upload/config/settings.json
+./extensions/upload/config/settings.js
 
 ```
-{
-  "provider": "minio",
-  "name": "Minio Server Provider",
-  "providerOptions": {
-    "public": "Q3AM3UQ867SPQQA43P2F",
-    "private": "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
-    "bucket": "strapi",
-    "internalEndpoint": "http://minio:9000",
-    "externalEndpoint": "https://minio.yourserver.io"
+module.exports = {
+  provider: "minio",
+  name: "Minio Server Provider",
+  providerOptions: {
+    public: process.env.MINIO_PUBLICKEY || "Q3AM3UQ867SPQQA43P2F",
+    private: process.env.MINIO_SECRET || "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
+    bucket: process.env.MINIO_BUCKET || "strapi",
+    internalEndpoint: process.env.MINIO_INTERNAL_ENDPOINT || "http://minio:9000",
+    externalEndpoint: process.env.MINIO_EXTERNAL_ENDPOINT || "https://minio.yourserver.io"
   }
-}
-
+};
 ```
 
 See https://github.com/strapi/strapi/tree/master/packages/strapi-provider-upload-aws-s3


### PR DESCRIPTION
I needed this plugin to be configurable with env vars to use it with docker / kubernetes.
